### PR TITLE
fix: return correct amount of news articles

### DIFF
--- a/richie/public/class-richie-public.php
+++ b/richie/public/class-richie-public.php
@@ -86,6 +86,7 @@ class Richie_Public {
         foreach( $sources as $source ) {
             $args = array(
                 'numberposts' => $source['number_of_posts'],
+                'exclude' => $found_ids
             );
 
 


### PR DESCRIPTION
We can pass array of ids to be excluded. Since we already track found
ids pass this array to the get_posts function. This way we get correct
amount of posts even if sources have duplicate posts.