### PR TITLE
chore: use newer images

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
   "config": {
     "platform": {
         "php": "7.0"
+    },
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   },
   "require-dev": {

--- a/docker-compose.phpunit.yml
+++ b/docker-compose.phpunit.yml
@@ -5,15 +5,13 @@ services:
     depends_on:
       - mysql_phpunit
     build: './docker/phpunit'
-    restart: always
     environment:
       PHPUNIT_DB_HOST: "mysql_phpunit"
     volumes:
       - "./richie:/app"
       - "testsuite:/tmp"
   mysql_phpunit:
-    image: "mysql:5.7"
-    restart: always
+    image: mariadb
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: "wordpress_test"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   db:
-    image: mysql:5.7
+    image: mysql/mysql-server:8.0.23
     volumes:
       - db_data:/var/lib/mysql
     restart: always

--- a/richie/tests/test-json-api.php
+++ b/richie/tests/test-json-api.php
@@ -398,7 +398,7 @@ class Test_JSON_API extends WP_UnitTestCase {
         $this->assertEquals( 200, $response->get_status() );
         $article = $response->data;
 
-        $this->assertObjectNotHasAttribute( 'title', $article );
+        $this->assertEquals( $article->title, $post->post_title );
         $this->assertEquals( $article->photos[0][0]->local_name, 'wp-content/uploads/richie.png' );
         $this->assertEquals( $article->photos[0][0]->remote_url, 'http://example.org/wp-content/uploads/richie.png' );
         $this->assertEquals( $article->photos[0][0]->caption, 'caption' );

--- a/richie/tests/test-richie-news-article.php
+++ b/richie/tests/test-richie-news-article.php
@@ -310,9 +310,9 @@ class Test_Richie_News_Article extends WP_UnitTestCase {
         $post->post_modified = $updated;
         $post->post_modified_gmt = get_gmt_from_date( $updated );
         $article = $stub->generate_article( $post, Richie_Article::EXCLUDE_METADATA );
-        $this->assertObjectNotHasAttribute( 'title', $article );
         $this->assertObjectNotHasAttribute( 'date', $article );
         $this->assertObjectNotHasAttribute( 'summary', $article );
+        $this->assertObjectHasAttribute( 'title', $article );
         $this->assertObjectHasAttribute( 'content_html_document', $article );
         $this->assertObjectHasAttribute( 'assets', $article );
         $this->assertObjectHasAttribute( 'photos', $article );


### PR DESCRIPTION
mysql 5.7 doesn't have arm (mac m1) binary support. Also fix failing
tests, broken after re-added title to api output.