### PR TITLE
Update release assets and collection header handling

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -11,7 +11,7 @@ module.exports = {
   github: {
     release: true,
     releaseName: "Richie News ${version}",
-    assets: ["releases/richie-${version}.zip"],
+    assets: ["releases/richie-news-${version}.zip"],
   },
   plugins: {
     "@release-it/bumper": {
@@ -48,6 +48,6 @@ module.exports = {
   },
   hooks: {
     "before:release":
-      "node scripts/sync-wp-version.mjs richie ${version} && npm run plugin-zip && mkdir -p releases && mv richie.zip releases/richie-${version}.zip",
+      "node scripts/sync-wp-version.mjs richie ${version} && npm run plugin-zip && mkdir -p releases && mv richie.zip releases/richie-news-${version}.zip",
   },
 };

--- a/richie/admin/class-richie-admin.php
+++ b/richie/admin/class-richie-admin.php
@@ -107,13 +107,8 @@ class Richie_Admin {
         $this->assets_option_name     = $plugin_name . '_assets';
         $this->adslots_option_name    = $plugin_name . '_adslots';
         $this->available_layout_names = array(
-            'big',
             'small',
-            'small_group_item',
-            'featured',
-            'full_width_text',
-            'text_left_square_thumb_right',
-            'none',
+            'featured'
         );
         add_action( 'added_option', array( __CLASS__, 'maybe_clear_alloptions_cache' ) );
         add_action( 'updated_option', array( __CLASS__, 'maybe_clear_alloptions_cache' ) );
@@ -692,7 +687,7 @@ class Richie_Admin {
         $section->add_field( 'richie_article_set', __( 'Article set', 'richie' ), 'article_set' );
         $section->add_field( 'adslot_position_index', __( 'Slot position', 'richie' ), 'input_field', array( 'description' => $slot_index_description, 'class' => '' ) );
 
-        $ad_providers = array( 'smart', 'google', 'readpeak' );
+        $ad_providers = array( 'smart', 'google' );
         $section->add_field( 'adslot_provider', __( 'Ad provider', 'richie' ), 'select_field', array( 'options' => $ad_providers ) );
         $section->add_field( 'adslot_ad_data', __( 'Ad data', 'richie' ), 'adslot_ad_data_editor' );
 

--- a/richie/public/class-richie-public.php
+++ b/richie/public/class-richie-public.php
@@ -198,10 +198,7 @@ class Richie_Public {
                         array_push( $found_ids, $p->ID );
                     }
 
-                    // Include collection header title to the first item only.
-                    if ( isset( $article_attributes['collection_header_title'] ) ) {
-                        unset( $article_attributes['collection_header_title'] );
-                    }
+                    // Keep collection header title for all items in the group.
                 }
             }
         }
@@ -642,5 +639,4 @@ class Richie_Public {
 
     }
 }
-
 

--- a/richie/tests/test-json-api.php
+++ b/richie/tests/test-json-api.php
@@ -146,6 +146,58 @@ class Test_JSON_API extends WP_UnitTestCase {
         $this->assertEquals( $id_list, array_slice( $posts, 0, 5 ) );
     }
 
+    public function test_group_items_include_collection_header_title() {
+        $term_id = self::factory()->term->create(
+            array(
+                'name'     => 'Test set',
+                'taxonomy' => 'richie_article_set',
+                'slug'     => 'test-set',
+            )
+        );
+
+        $sources = array();
+
+        $sources[1] = array(
+            'id'                => 1,
+            'name'              => 'group source',
+            'number_of_posts'   => 3,
+            'order_by'          => 'date',
+            'order_direction'   => 'ASC',
+            'article_set'       => $term_id,
+            'list_layout_style' => 'small_group_item',
+            'list_group_title'  => 'group title',
+            'allow_duplicates'  => 0,
+        );
+
+        $sources[2] = array(
+            'id'                => 2,
+            'name'              => 'non-group source',
+            'number_of_posts'   => 2,
+            'order_by'          => 'date',
+            'order_direction'   => 'ASC',
+            'article_set'       => $term_id,
+            'list_layout_style' => 'small',
+        );
+
+        add_option( 'richienews_sources', array( 'published' => $sources ) );
+
+        self::factory()->post->create_many( 10 );
+
+        $request = new WP_REST_Request( 'GET', '/richie/v1/news/test-set' );
+        $request->set_query_params( array( 'token' => 'testtoken' ) );
+        $response = $this->server->dispatch( $request );
+        $articles = $response->data['articles'];
+
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertEquals( 5, count( $articles ) );
+
+        $group_articles = array_slice( $articles, 0, 3 );
+        foreach ( $group_articles as $article ) {
+            $this->assertArrayHasKey( 'collection_header_title', $article );
+            $this->assertEquals( 'group title', $article['collection_header_title'] );
+        }
+    }
+
     public function test_get_v1_news_feed() {
         $term_id = self::factory()->term->create(
             array(


### PR DESCRIPTION
Summary
- adjust release packaging hook to rename the ZIP to `richie-news-${version}` so releases use the correct asset name (`.release-it.js:11`)
- trim admin layout and ad provider options to the supported set (`richie/admin/class-richie-admin.php:107,692`)
- keep collection header titles on every grouped article and add a regression test for it (`richie/public/class-richie-public.php:198`, `richie/tests/test-json-api.php:146`)

Testing
- Not run (not requested)